### PR TITLE
Airlock redirect

### DIFF
--- a/ui/app/src/Main.elm
+++ b/ui/app/src/Main.elm
@@ -17,6 +17,7 @@ import Views.SilenceForm.Types exposing (initSilenceForm)
 import Views.SilenceList.Types exposing (initSilenceList)
 import Views.SilenceView.Types exposing (initSilenceView)
 import Views.Status.Types exposing (initStatusModel)
+import Array
 
 
 main : Program Json.Value Model Msg
@@ -121,6 +122,7 @@ init flags url key =
             key
             { firstDayOfWeek = firstDayOfWeek
             }
+            (  Array.get 1 (Array.fromList (String.split "?" (Url.toString url)) ) |> Maybe.withDefault "" )
         )
 
 

--- a/ui/app/src/Types.elm
+++ b/ui/app/src/Types.elm
@@ -29,6 +29,7 @@ type alias Model =
     , expandAll : Bool
     , key : Key
     , settings : SettingsView.Model
+    , query : String
     }
 
 

--- a/ui/app/src/Updates.elm
+++ b/ui/app/src/Updates.elm
@@ -48,9 +48,7 @@ update msg ({ basePath, apiUrl } as model) =
             )
 
         NavigateToSilenceFormNew params ->
-            ( { model | route = SilenceFormNewRoute params }
-            , Task.perform (NewSilenceFromMatchersAndComment model.defaultCreator >> MsgForSilenceForm) (Task.succeed params)
-            )
+            ( model, Navigation.load ("https://airlock.sre.gs.com/alertmanager/silence?" ++ model.query) )
 
         NavigateToSilenceFormEdit uuid ->
             ( { model | route = SilenceFormEditRoute uuid }, Task.perform identity (Task.succeed <| (FetchSilence uuid |> MsgForSilenceForm)) )


### PR DESCRIPTION
Going to the Create New Silence page now redirects straight to Airlock, maintaining any query params that were initially there.